### PR TITLE
fix missing variable

### DIFF
--- a/kisscharm.mac
+++ b/kisscharm.mac
@@ -6432,6 +6432,7 @@ Sub Main
 
 					| This loads and declares the CharmImmune var
 					/call LoadIni "${ZoneName}" CharmImmune   string      "List up to 10 mobs. Use full names i.e. a green snake,a blue tiger,a wide eye ooze or NULL" NULL ${InfoFileName}
+                			/call LoadIni "${ZoneName}" AAMezImmune int         0 0 ${InfoFileName}
 					/call CreateTimersCharm
 						|KissAssist_Info variables
 						/if (!${CharmImmune.Find[null]} && ${CharmImmune.Length}>0) {


### PR DESCRIPTION
Forgot to declare and initialize. 
 /call LoadIni "${ZoneName}" AAMezImmune int         0 0 ${InfoFileName}