### PR TITLE
Charm and Combat Updates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,7 @@
-#Zip releases
-*.zip
+/*
+!.gitignore
+!LICENSE
+!/README.md
+!/KAssist
+!/KAssist/*
+!kisscharm.mac

--- a/KAssist/KS_Charm.inc
+++ b/KAssist/KS_Charm.inc
@@ -35,8 +35,21 @@
 | -------------------------------------------------------------------------------------
     Sub DoCharmStuff(string SentFrom)
 		DEBUGN DoCharmStuff: Check for a pet? = ${Me.Pet.ID}
-		/if (${Me.Pet.ID}>0 || !${CharmOn}) /return
-		
+		/if (${Me.Pet.ID} || !${CharmOn}) /return
+        |-- if charm zone is not emptu and we don't have a pet check that we want to Recharm pet and the the zone matches the one we want.
+      /if (${CharmPetZone.NotEqual[null]} && !${Me.Pet.ID}) {
+        /if (${Select[${CharmKeep},1]} && ${CharmPetZone.NotEqual[${Zone.ShortName}]}) {
+            DEBUGN DoCharmStuff: Charm Pet not in: ${Zone.ShortName} go to: ${CharmPetZone} to find it.
+           | /call BroadCast y "DoCharmStuff: Charm Pet not in: ${Zone.ShortName} go to: ${CharmPetZone} to find it."
+            /return
+        }
+        /if (${Select[${CharmKeep},1]} && ${CharmPetZone.Equal[${Zone.ShortName}]} && !${Bool[${Spawn[${CharmPet}].ID}]}) {
+            DEBUGN DoCharmStuff: Charm Pet is Dead! Resetting CharmedPetID 
+            /call BroadCast m "*** Charm Pet is Dead! Resetting CharmedPetID ***"
+            /varset CharmPet 0
+            /varset CharmPetZone null
+        }
+      }
 		/varset PetActiveState 0
         /if (${EventByPass}!=2) {
             /varset EventByPass 1
@@ -69,6 +82,7 @@
 |            /return
 |        }
 		/if (${CharmKeep}==0) /varset CharmPet 0
+
         | CharmOn - 0=Off/1=On
         /for i 1 to ${XSlotTotal}
             /varset skipFlag 0
@@ -219,9 +233,10 @@
 					/call BroadCast g "*** Charm Sucessfull ***"						
 					/varset CharmMobDone 1
 					/squelch /pet back off
-					/if (${CharmKeep}) {
+					/if (${Select[${CharmKeep},1]}) {
                         /varset CharmPet ${Me.Pet.ID}
                         /echo "Charm Pet ID: ${CharmPet}"
+                        /varset CharmPetZone ${Zone.ShortName}
                     }
                     /if (${IAmABard} && ${CombatStart} && ${Bool[${Target.Charmed}]}) {
                         | /varset MyTargetID ${Int[${Me.GroupAssistTarget.ID}]}
@@ -237,14 +252,16 @@
                 |--we're not charming leave
                 /return
             }
-			/if (!${Me.Pet.ID}) {
+			/if (!${Me.Pet.ID} && ${CharmKeep}) {
+                /if (${CharmPetZone.Equal[${Zone.ShortName}]} && ${Bool[${Spawn[${CharmPet}].ID}]}) {
 				/varset PetActiveState 0
 				/call BroadCast g "** CHARM FAIL **"
-				/if (${CharmKeep} && ${i}==${XSlotTotal}) {
+				/if (${Select[${CharmKeep},1]} && ${i}==${XSlotTotal} && ${CharmPetZone.Equal[${Zone.ShortName}]}) {
 					/call BroadCast p "Old pet is Not in Range!"
 				|--	/varset CharmPet 0
 				|--	/echo "CharmPetID: ${CharmPet}"
-				}               
+				}  
+                }             
             }
             /next i
 		DEBUGN DoCharmStuff: Leave

--- a/KAssist/KS_Combat.inc
+++ b/KAssist/KS_Combat.inc
@@ -19,6 +19,9 @@
                 /return
             }
         }
+        /if (${Target.Charmed.ID} && ${Select[${Role},tank,pullertank,pettank,pullerpettank]}) {
+            /if (${Bool[${Target.Charmed}]}) /call MobRadar los ${MeleeDistance} CheckForCombat                
+        }
         /if (${Select[${Role},tank,pullertank]}==0 && (${Me.Song[Rallying Call].ID} || ${Me.Song[Rallying Solo].ID})) /return
         DEBUGCOMBAT Combat Enter
         /declare CombatRadius int   local ${If[${Spawn[id ${MyTargetID}].MaxRangeTo}>${MeleeDistance},${Math.Calc[${Spawn[id ${MyTargetID}].MaxRangeTo}+5]},${MeleeDistance}]}
@@ -937,6 +940,9 @@
             }
             /call CheckForAdds CheckForCombat
             /if (${Select[${Role},tank,pullertank]}) {
+            /if (${Bool[${Target.Charmed}]}) {
+                /call MobRadar los ${MeleeDistance} CheckForCombat
+            }
                 | If tank is assisting puller and in chase mode
                 /if (${WhoToChase.NotEqual[${Me}]} && ${ChaseAssist}) /call DoWeChase
                 /if (${ReturnToCamp} && ((!${MobCount} && ${Math.Distance[${CampYLoc},${CampXLoc},${CampZLoc}]}>15) || (${MobCount}==1 && ${AggroTargetID} && ${Math.Distance[${CampYLoc},${CampXLoc},${CampZLoc}]}>75))) /call DoWeMove 1 checkforcombat
@@ -952,7 +958,7 @@
             } else /if (${Role.NotEqual[manual]} ) {
                 /if (${MyTargetID} && (${Spawn[${MyTargetID}].Type.Equal[Corpse]} || !${Spawn[${MyTargetID}].ID})) /call CombatReset 0 CheckForCombat2
             }
-            /call MobRadar los ${MeleeDistance} CheckForCombat
+            
 			/if (${CharmOn}==1) /call CharmRadar los ${MeleeDistance} CheckForCombat
 			
             DEBUGCOMBAT CheckForCombat MobCount: ${MobCount} AggroTargetID: ${AggroTargetID} ChainPull: ${ChainPull} ${SkipCombat} ${MezMobFlag}
@@ -1236,6 +1242,9 @@
         /declare MobType string local
         /declare MeleeDistanceCheck int local ${MeleeDistance}
         /varset ValidTarget 0
+        /if (${Target.Charmed.ID} && ${Select[${Role},tank,pullertank,pettank,pullerpettank]}) {
+            /if (${Bool[${Target.Charmed}]}) /call MobRadar los ${MeleeDistance} CheckForCombat                
+        }
         /if (${SpawnID}) {
            /varset MobID ${Spawn[${SpawnID}].ID}
            /varset MobName ${Spawn[${SpawnID}].CleanName}
@@ -1596,6 +1605,9 @@
         /declare AggroPCT     int    local
         /declare AggroTarget  string local
         /declare AggroTID     int    local
+        /if (${Target.Charmed.ID} && ${Select[${Role},tank,pullertank,pettank,pullerpettank]}) {
+            /if (${Bool[${Target.Charmed}]}) /call MobRadar los ${MeleeDistance} CheckForCombat                
+        }
         /if (${IAmMA} && ${TargetSwitchingOn} && ${Target.ID} && ${Target.ID}!=${MyTargetID} && ${CombatStart}) /call CombatTargetCheck 1
         /if (!${MyTargetID}) /return
         /for i 1 to ${Aggro.Size}

--- a/KAssist/KS_Events.inc
+++ b/KAssist/KS_Events.inc
@@ -78,7 +78,7 @@
         /if (${EventByPass}==1) /return
         /varset GoMByPass 1
         /varset EventByPass 2
-        /call CombatTargetCheck 1
+        /call CombatTargetCheck 2
         /call DoCharmStuff Event_CharmBroke
         /varset EventByPass 0
         /varset GoMByPass 0
@@ -357,6 +357,21 @@
             /if (${PullWith.Equal[Ranged]} && ${Target.Distance}<=30 && ${Target.LineOfSight}) /varset ToClose 1
         }
         DEBUGN Leave Event_CantHit
+    /return
+| -------------------------------------------------------------------------------------
+| SUB: Event MeleeOOR
+| -------------------------------------------------------------------------------------
+    Sub Event_MeleeOOR
+        |/varset EventFlag 1
+        DEBUGN Event_MeleeOOR
+        | Reset position via stick
+        /if (${Pulling}) {
+            /varset CantHit 1
+            /if (${PullWith.Equal[Ranged]} && ${Target.Distance}<=30 && ${Target.LineOfSight}) /varset ToClose 1
+        } else {
+            /squelch /nav target
+        }
+        DEBUGN Leave Event_MeleeOOR
     /return
 | -------------------------------------------------------------------------------------
 | SUB: Event Missing
@@ -820,12 +835,43 @@
 | SUB: Event CharmBackO - Charmed a mob Back off and reset combat
 | ----------------------------------------------------------------------------
     Sub Event_CharmBackO(string Line)
+        /declare t_Wait      timer local 0
+        /declare i_Target    int   local ${Int[${Target.ID}]}
+        /declare i_Flag1     int   local 0
         /varset EventFlag 1
 		/if (${IAmMA}) {
-			/call Bind_BackOff 1 10
-			/call Bind_BackOff 0 10
-			/call BroadCast g "Reset combat for Charmed Pet"
-		}
+        /call MobRadar los ${MeleeDistance} CombatReset
+            /varset DPSPaused 2
+        |-- Leave Combat
+            /if (${UseMQ2Melee}) /squelch /melee off
+            /squelch /attack off
+            /if (${Stick.Active}) /stick off
+            /if (${IAmMA}) {
+                /if (${Me.Casting.ID}) {
+                    /stopcast
+                    /varset CastResult CAST_CANCELLED
+                }
+        |-- Find New Target
+                /echo Pausing for Charmed target. Switching to new target now.
+                /varset t_Wait 30
+                /while (${t_Wait} && !${i_Flag1}) {
+                    /if (${Target.ID} && ${Target.ID}!=${i_Target}) /varset i_Flag1 1
+                    /delay 5
+                }
+                /if (${i_Flag1}) {
+                    /varset i_Flag1 ${TargetSwitchingOn}
+                    /varset TargetSwitchingOn 1
+                    /call CombatTargetCheck 2
+        |-- Re-Enter Combat
+                    /varset TargetSwitchingOn ${i_Flag1}
+                    /echo Target Switched because of Charmed Pet.
+                } else {
+                    /echo Target NOT Switched. You can always try again.
+                }
+            }
+            /if (${DPSPaused}==2 && ${UseMQ2Melee}) /squelch /melee on
+            /varset DPSPaused 0
+        }
         /doevents flush CharmBackO
     /return
 | ----------------------------------------------------------------------------

--- a/kisscharm.mac
+++ b/kisscharm.mac
@@ -7948,6 +7948,7 @@ Sub Main
             /declare CharmArray[50,3]         string      outer       NULL
             /declare CharmBroke               int         outer       0
             /declare CharmImmuneIDs           string      outer
+            /declare CharmPetZone           string      outer       null
             /declare CharmMobAECount          int         outer       0
 			/declare CharmAEClosest				int			outer 		0
             /declare CharmMobCount            int         outer       0

--- a/kisscharm.mac
+++ b/kisscharm.mac
@@ -133,7 +133,9 @@
 #Event KTInvite          "[MQ2] KTInvite #1#"
 #Event KTSay             "[MQ2] KTSay #1# #2#"
 #Event KTTarget          "[MQ2] KTTarget #1#"
-|#Event CharmBackO	 	 "#*#Charm Sucessfull#*#"
+#Event CharmBackO	 	 "#*#Charm Sucessfull#*#"
+#Event CharmBackO	 	 "#*#JUST CHARMED#*#"
+#Event CharmBackO	 	 "#*#JUST RECHARMED#*#"
 #Event LeftGroup         "#1# has left the group."
 #Event MezBroke          "#1# has been awakened by #2#."
 |#Event CharmBroke        "Your #1# spell has worn off of #2#."
@@ -153,6 +155,7 @@
 #Event Zoned             "You have entered#*#"
 #Event AskForBuffs       "#1# tells you,#*#Buffs Please!#*#"
 #Event AskForBuffs       "#1# says,#*#Buffs Please!#*#"
+|#Event MeleeOOR          "Your target is too far away, get closer#*#"
 |**************************************** COMBAT EVENTS ***********************************************|
 #Event AttackCalled      "<#1#>#*#TANKING-> #*# <- ID:#2#"
 #Event AttackCalled     "[ #1# (#*#) ]#*#TANKING-> #*# <- ID:#2#"
@@ -3203,7 +3206,7 @@ Sub Main
                 /for i 1 to ${MobCount}
                     /varset NMob ${NearestSpawn[${i},npc targetable los radius ${CountRadius} zradius 50 noalert 3].ID}
                     /if (${i}>${XSlotTotal}) /break
-                    /if (${NMob} && (${Spawn[${NMob}].Type.Equal[Corpse]} || !${Spawn[${NMob}].ID})) {
+                    /if (${NMob} && (${Spawn[${NMob}].Type.Equal[Corpse]} || !${Spawn[${NMob}].ID}) || ${Spawn[${NMob}].Master}) {
                         |/call RemoveFromArray AddsArray ${Select[${NMob},${AddsArray[1,1]},${AddsArray[2,1]},${AddsArray[3,1]},${AddsArray[4,1]},${AddsArray[5,1]},${AddsArray[6,1]},${AddsArray[7,1]},${AddsArray[8,1]},${AddsArray[9,1]},${AddsArray[10,1]},${AddsArray[11,1]},${AddsArray[12,1]},${AddsArray[13,1]}]}
                         /varcalc i_CorpseCount ${i_CorpseCount}+1
                     }
@@ -5596,7 +5599,7 @@ Sub Main
                 }
                 /echo Pausing for new target. Switch to new target now.
                 /varset t_Wait 30
-                /beep
+                |/beep
                 /while (${t_Wait} && !${i_Flag1}) {
                     /if (${Target.ID} && ${Target.ID}!=${i_Target}) /varset i_Flag1 1
                     /delay 5
@@ -8031,6 +8034,7 @@ Sub Main
             /declare MezAETimer             timer       outer       0
             /declare MezArray[50,3]         string      outer       NULL
             /declare MezBroke               int         outer       0
+            /declare MeleeOOR               int         outer       0
             /declare MezImmuneIDs           string      outer
             /declare MezMobAECount          int         outer       0
             /declare MezMobCount            int         outer       0


### PR DESCRIPTION
-  Added a variable to track CharmPetZone for when we are using Charm Keep. 
- - This will prevent us from trying to re-charm that id in other zones, and allows us to reset the CharmPet variable when the spawn dies, instead of waiting for user intervention.
- Melee should behave better around charmed pets. we now check against ${Spawn.Master} and remove it from the array if its true. 
- Added a few more calls to check for charmed pets by MA.